### PR TITLE
fixed broken method on werkzeug update

### DIFF
--- a/fdtsqlalchemy/__init__.py
+++ b/fdtsqlalchemy/__init__.py
@@ -14,6 +14,7 @@ from flask_debugtoolbar.utils import format_sql
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_debugtoolbar import module
 import itsdangerous
+import greenlet
 
 from jinja2 import Environment, PackageLoader
 
@@ -105,7 +106,7 @@ class SQLADebugPanel(DebugPanel):
             cls.package_names = []
 
         cls._engine = engine
-        scopefunc = _app_ctx_stack.__ident_func__
+        scopefunc = greenlet.getcurrent
         cls._locals = ScopedRegistry(dict, scopefunc)
 
         @app.teardown_request

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,16 @@ from setuptools import setup, find_packages
 
 setup(
     name='fdt-sqlalchemy',
-    version='0.0.4',
+    version='0.0.5',
     description='Flask-debugtoolbar configurable SQLAlchemy panel',
-    author='Charles Lavery',
+    author='Charles Lavery & Davide Marchi',
     author_email='charles.lavery@gmail.com',
     url='https://github.com/clavery/fdt-sqlalchemy',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'SQLAlchemy>=0.9.0',
-        'Flask-DebugToolbar>=0.9.0',
+        'SQLAlchemy>=2.0.4',
+        'Flask-DebugToolbar>=0.13.1',
     ],
     license='BSD',
     zip_safe=False,


### PR DESCRIPTION
The __init__ method was broken with the latest updates of Werkzeug, I've put a little patch to fix it 